### PR TITLE
Update CSS to not cover floating items

### DIFF
--- a/client/graphviz.css
+++ b/client/graphviz.css
@@ -1,4 +1,7 @@
-.graphviz {position: relative;}
+.graphviz {
+  clear: both;
+  position: relative;
+}
 .graphviz:hover .actions {
   position: absolute; top: 0; right: 0;
   padding: 5px; background: white; box-shadow: 2px 2px 6px #999;


### PR DESCRIPTION
Issue discovered while looking at the update to the NPL wiki with Ward. When a graphviz item follows item that float, e.g. image plugin, it covers them preventing interaction with them. See image below.
<img width="443" alt="Screenshot 2025-02-15 at 11 58 41" src="https://github.com/user-attachments/assets/cbc7373e-ae9c-42d9-8de4-21d44ec67185" />

This change is to add a declaration to the `.graphviz` selector to move it clear of any floating items. 